### PR TITLE
Send playEmoji and pauseEmoji as webhook params

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,16 @@ In order to run this app:
 Then run the app as follows:
 
 ```
-$ PLAY_EMOJI="speaker" \
-  PAUSE_EMOJI="mute" \
-  TOKEN=<token> \
-  PLAYER=<player>
+$ TOKEN=<token> \
+  PLAYER=<player> \
   [USERNAME=<username>]
   node index.js
 ```
 
 > ⚠️ You'll need to use the USERNAME env variable if you're playing music as a shared user.
 
-Finally, add the webhook to https://app.plex.tv/web/app#!/account/webhooks (it'll be http://localhost:10000).
+Add the webhook to https://app.plex.tv/web/app#!/account/webhooks replacing the `playEmoji` and `pauseEmoji` params with your preferred Slack emoji.
+  * http://localhost:10000?playEmoji=speaker&pauseEmoji=mute
 
 Alternatively, deploy straight to Heroku now:
 

--- a/index.js
+++ b/index.js
@@ -1,44 +1,68 @@
-var express = require('express')
-  , request = require('request')
-  , multer  = require('multer');
+const express = require('express');
+const request = require('request');
+const multer = require('multer');
 
-var upload = multer({ dest: '/tmp/' });
-var app = express();
-var isPlaying = false;
-
-function createOnResponseHandler(action) {
-  return function onResponse(error, response, body) {
-    const parsedBody = !error && response.statusCode === 200 && JSON.parse(body);
-    const errorMessage = error || (!parsedBody.ok && parsedBody.error);
-
-    if (errorMessage) {
-      console.log(`error posting ${action} status: ${errorMessage}`);
-    }
-  }
-}
+const upload = multer({ dest: '/tmp/' });
+const app = express();
 
 app.post('/', upload.single('thumb'), function (req, res, next) {
-  var payload = JSON.parse(req.body.payload);
+  const payload = JSON.parse(req.body.payload);
 
-  var validUser   = payload.Account.id === 1 || payload.Account.title === process.env.USERNAME;
-  var validPlayer = payload.Player.uuid === process.env.PLAYER;
+  const isValidUser = (
+    payload.Account.id === 1 ||
+    payload.Account.title === process.env.USERNAME
+  );
+
+  const isValidPlayer = payload.Player.uuid === process.env.PLAYER;
 
   // If the right player is playing a track, display a notification.
-  if (validPlayer && validUser && payload.Metadata.type === 'track') {
-    const common = `token=${process.env.TOKEN}`;
-    if (payload.event == "media.play" || payload.event == "media.resume") {
-      request.post({
-        headers: {'content-type' : 'application/x-www-form-urlencoded'},
-        url:     'https://slack.com/api/users.profile.set',
-        body:    `${common}&profile=%7B%22status_text%22%3A%22${encodeURIComponent(payload.Metadata.originalTitle || payload.Metadata.grandparentTitle)}%20-%20${encodeURIComponent(payload.Metadata.title)}%22%2C%22status_emoji%22%3A%22%3A${process.env.PLAY_EMOJI}%3A%22%7D`
-      }, createOnResponseHandler('play'));
-    } else if (payload.event == "media.pause" || payload.event == "media.stop") {
-      request.post({
-        headers: {'content-type' : 'application/x-www-form-urlencoded'},
-        url:     'https://slack.com/api/users.profile.set',
-        body:    `${common}&profile=%7B%22status_text%22%3A%22%22%2C%22status_emoji%22%3A%22%3A${process.env.PAUSE_EMOJI}%3A%22%7D`
-      }, createOnResponseHandler('stop'));
-    }
+  const isValidRequestType = (
+    isValidPlayer &&
+    isValidUser &&
+    payload.Metadata.type === 'track'
+  );
+
+  const isPlayEvent = isValidRequestType &&
+    (payload.event == 'media.play' || payload.event == 'media.resume');
+
+  const isPauseEvent = isValidRequestType &&
+    (payload.event == 'media.pause' || payload.event == 'media.stop');
+
+  if (isPlayEvent || isPauseEvent) {
+    const statusText = isPlayEvent ?
+      `${payload.Metadata.originalTitle || payload.Metadata.grandparentTitle} - ${payload.Metadata.title}` :
+      '';
+
+    const playEmoji = req.query.playEmoji || process.env.PLAY_EMOJI || '';
+    const pauseEmoji = req.query.pauseEmoji || process.env.PAUSE_EMOJI || '';
+    const token = process.env.TOKEN;
+    const statusEmoji = isPlayEvent ? playEmoji : pauseEmoji;
+
+    const params = [
+      ['token', token],
+      ['profile', JSON.stringify({
+        status_text: statusText,
+        status_emoji: statusEmoji.length >= 1 ? `:${statusEmoji}:` : statusEmoji
+      })]
+    ];
+
+    request.post({
+      headers: {'content-type' : 'application/x-www-form-urlencoded'},
+      url: 'https://slack.com/api/users.profile.set',
+      body: params.
+        map(([name, value]) => (
+          `${encodeURIComponent(name)}=${encodeURIComponent(value)}`)
+        ).
+        join('&')
+    }, (error, response, body) => {
+      const parsedBody = !error && response.statusCode === 200 && JSON.parse(body);
+      const errorMessage = error || (!parsedBody.ok && parsedBody.error);
+      const action = isPlayEvent ? 'play' : 'stop';
+
+      if (errorMessage) {
+        console.log(`error posting ${action} status: ${errorMessage}`);
+      }
+    });
   }
 
   res.sendStatus(200);


### PR DESCRIPTION
Allow providing `playEmoji` and `pauseEmoji` params from webhooks.

Consolidate params-generation
Use `const` instead of `var`
Use single-quotes consistently
Remove unused `isPlaying` local
Retain backwards support for `PLAY_EMOJI` and `PAUSE_EMOJI` environment variables

### Steps to test
* Launch server without `PLAY_EMOJI` and `PAUSE_EMOJI` environment variables.
* Configure webhook url to provide `?playEmoji=speaker&pauseEmoji=mute` params
* Pause and play music; expect to see param-based emojis reflected in Slack status