### PR TITLE
Allow any player

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ $ TOKEN=<token> \
 
 > ⚠️ You'll need to use the USERNAME env variable if you're playing music as a shared user.
 
-- Add a webhook to https://app.plex.tv/web/app#!/account/webhooks, replacing the `playEmoji` and `pauseEmoji` params with your preferred Slack emoji:
+- Add a webhook to https://app.plex.tv/web/app#!/account/webhooks, replacing the `playEmoji`, `pauseEmoji`, and `player` params with your preferred Slack emoji and player identifier:
 
-  `http://localhost:10000?playEmoji=plexamp-outline&pauseEmoji=plexamp-outline-desaturated`
+  `http://localhost:10000?playEmoji=plexamp-outline&pauseEmoji=plexamp-outline-desaturated&player=android-ab73d9387`

--- a/app.json
+++ b/app.json
@@ -7,17 +7,21 @@
   "addons": [
   ],
   "env": {
+    "TOKEN": {
+      "description": "The Slack legacy token (generate on https://api.slack.com/custom-integrations/legacy-tokens).",
+      "required": true
+    },
     "PAUSE_EMOJI": {
-      "description": "Emoji to use when paused"
+      "description": "Emoji to use when paused if none provided in querystring.",
+      "required": false
     },
     "PLAY_EMOJI": {
-      "description": "Emoji to use when playing"
-    },
-    "TOKEN": {
-      "description": "The Slack legacy token (generate on https://api.slack.com/custom-integrations/legacy-tokens)"
+      "description": "Emoji to use when playing if none provided in querystring.",
+      "required": false
     },
     "PLAYER": {
-      "description": "The identifier of the Plex player to watch"
+      "description": "The identifier of the Plex player to watch. If not provided, nor in the querystring, any player playing music will be accepted.",
+      "required": false
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ app.post('/', upload.single('thumb'), function (req, res, next) {
     payload.Account.title === process.env.USERNAME
   );
 
-  const isValidPlayer = payload.Player.uuid === process.env.PLAYER;
+  const player = req.query.player || process.env.PLAYER;
+  const isValidPlayer = player ? player === payload.Player.uuid : true;
 
   // If the right player is playing a track, display a notification.
   const isValidRequestType = (


### PR DESCRIPTION
This does a few things:

- Allows for player ID in the querystring as well as the environment variables.
- Makes the player _optional_ so that you can get Slack updates for any player playing music.
- Marks the environment variables that are optional as such in Heroku's `app.json` file.