### PR TITLE
feat: Don't mount service account token by deault

### DIFF
--- a/charts/music-notifications/Chart.yaml
+++ b/charts/music-notifications/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/music-notifications/templates/deployment.yaml
+++ b/charts/music-notifications/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         {{- include "music-notifications.labels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/music-notifications/values.yaml
+++ b/charts/music-notifications/values.yaml
@@ -63,6 +63,7 @@ resources:
 imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: ''
+automountServiceAccountToken: false
 
 service:
   type: ClusterIP


### PR DESCRIPTION
There is no reason to mount the SA token by default.

Just in case, I moved it to a parameter with a default value of false
